### PR TITLE
fix bug with +lang elvish

### DIFF
--- a/commands/commands/social.py
+++ b/commands/commands/social.py
@@ -2878,7 +2878,7 @@ class CmdLanguages(ArxCommand):
             return
         if not self.switches:
             args = self.args.lower()
-            if args == "Elvish" or args == "common":
+            if args == "elvish" or args == "common":
                 self.caller.attributes.remove("currently_speaking")
                 self.msg("{wYou are now speaking Elvish.{n")
                 return

--- a/server/conf/base_settings.py
+++ b/server/conf/base_settings.py
@@ -44,7 +44,7 @@ MAX_CHAR_LIMIT = 8000
 DEBUG = False
 CHANNEL_COMMAND_CLASS = "commands.commands.channels.ArxChannelCommand"
 BASE_ROOM_TYPECLASS = "typeclasses.rooms.ArxRoom"
-DEFAULT_HOME = "#30"
+DEFAULT_HOME = config("DEFAULT_HOME", default="#30")
 MULTISESSION_MODE = 1
 COMMAND_DEFAULT_MSG_ALL_SESSIONS = True
 ADDITIONAL_ANSI_MAPPINGS = [(r'%r', "\r\n"),]


### PR DESCRIPTION
The string that args gets compared to will _always_ be lowercase, because it gets lower-cased on the previous line. This does not change the value that's actually stored on the object, that still is capitalized.

Additionally, I made the DEFAULT_HOME configurable.