### PR TITLE
bug fixes

### DIFF
--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -4,6 +4,7 @@ TELNET_PORTS = [4000]
 WEBSERVER_PORTS = [(4001, 4005)]
 SERVERNAME = "Ithir"
 GAME_SLOGAN = "The Return to Glory"
+USE_TZ = True
 
 # try:
 #    from server.conf.secret_settings import *

--- a/typeclasses/scripts/weekly_events.py
+++ b/typeclasses/scripts/weekly_events.py
@@ -131,10 +131,6 @@ class WeeklyEvents(RunDateMixin, Script):
         self.cleanup_stale_attributes()
         self.post_inactives()
         self.count_poses()
-        self.db.pose_counter = (self.db.pose_counter or 0) + 1
-        if self.db.pose_counter % 4 == 0:
-            self.db.pose_counter = 0
-            self.count_poses()
         self.db.week += 1
         self.reset_action_points()
         self.inform_creator.create_and_send_informs()


### PR DESCRIPTION
The USE_TZ setting is meant to resolve the complaints about naive time versus zone time. The other commit ensures that the pose count only gets updated once, instead of twice every 4 weeks.